### PR TITLE
feat(p3): complete tabular data cleaning with pandas part 2 (drills 05-08)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ notes.md
 sample.txt
 
 .venv/
+
+notes.md

--- a/pillar3/tabular_data_cleaning/README.md
+++ b/pillar3/tabular_data_cleaning/README.md
@@ -77,24 +77,17 @@ python -m tabular_data_cleaning.normalize_csv
 
 ---
 
-### Drill 07 — Minimal cleaning of free-text fields
+### Drill 07 — [Minimal cleaning of free-text fields](handle_free_text_fields.py)
 **Goal:** Avoid corrupting descriptive data.  
 - Apply `.str.strip()` only
 - No casing changes, no replacements, no normalization
 
 ---
 
-### Drill 08 — Remove exact duplicate rows
+### Drill 08 — [Remove exact duplicate rows](remove_duplicate_rows.py)
 **Goal:** Deduplicate safely.  
 - Use `df.drop_duplicates()`
 - No fuzzy matching, no subset logic
 - Log before/after row counts
 
 ---
-
-## Completion Criteria
-
-These drills are considered complete when:
-- You can write them without looking up documentation
-- Each script is fully understood line by line
-- The process feels mechanical and boring

--- a/pillar3/tabular_data_cleaning/README.md
+++ b/pillar3/tabular_data_cleaning/README.md
@@ -24,38 +24,36 @@ Run any script as a module:
 python -m tabular_data_cleaning.normalize_csv
 ```
 
-### Drill 01 — Read CSV as strings on purpose
+### Drill 01 — [Read CSV as strings on purpose](read_csv.py)
 **Goal:** Preserve identifiers and avoid numeric surprises.  
 - Use `pd.read_csv(..., dtype="string", keep_default_na=False)`
 - Verify leading zeros are preserved
 
 ---
 
-### Drill 02 — Trim whitespace and standardize empty strings
+### Drill 02 — [Trim whitespace and standardize empty strings](normalize_csv.py)
 **Goal:** Normalize trivial missing values.  
 - Apply `.str.strip()` to selected string columns  
 - Replace empty strings `""` with `pd.NA`
 
 ---
 
-### Drill 03 — Replace placeholder values with nulls
+### Drill 03 — [Replace placeholder values with nulls](handle_nulls.py)
 **Goal:** Make missing data explicit.  
 - Replace placeholders like `"."`, `"--"`, `"0"` with `pd.NA`
 - Apply replacements **only where semantically correct**
 
 ---
 
-### Drill 04 — Remove trailing `.0` from code-like columns
+### Drill 04 — [Remove trailing .0 from code-like columns](fix_cnae_cols.py)
 **Goal:** Fix formatting artifacts from numeric parsing.  
 - Clean values like `"6910.0"` → `"6910"`
 - Use regex replacement anchored at end of string
 
 ---
 
-### Drill 04.1 — Normalize address portal numbers
-
+### Drill 04.1 — [Normalize address portal numbers](fix_portalt_col.py)
 **Goal:** Enforce domain rules for address portal numbers without affecting free-text values.
-
 - Apply the rule: portal numbers must be integers (no decimals)
 - Remove trailing `.0` from numeric portal values (e.g. `"6.0"` → `"6"`)
 - Do **not** modify non-numeric tokens (`"PBJ"`, `"BAJO"`, `"ENT"`, etc.)
@@ -63,14 +61,14 @@ python -m tabular_data_cleaning.normalize_csv
 
 ---
 
-### Drill 05 — Enforce year as nullable integer
+### Drill 05 — [Enforce year as nullable integer](cast_year_to_int.py)
 **Goal:** Apply correct numeric typing without data loss.  
 - Convert year columns using `pd.to_numeric(errors="coerce")`
 - Cast to pandas nullable integer type `Int64`
 
 ---
 
-### Drill 06 — Preserve identifiers as strings
+### Drill 06 — [Preserve identifiers as strings](preserve_codes_as_strings.py)
 **Goal:** Protect codes and identifiers.  
 - Ensure columns like `dnici`, `codpost`, `cod_cmun` remain `string`
 - Never cast identifiers to numeric

--- a/pillar3/tabular_data_cleaning/cast_year_to_int.py
+++ b/pillar3/tabular_data_cleaning/cast_year_to_int.py
@@ -1,0 +1,51 @@
+"""
+Drill 05 — Enforce year as nullable integer
+
+Goal:
+Apply correct numeric typing to year fields without losing information.
+
+Rules:
+- Convert the `anio` column using pd.to_numeric(errors="coerce")
+- Cast the result to pandas nullable integer type (Int64)
+- Preserve missing or invalid values as pd.NA
+- Do not infer, fill, or impute missing years
+- Do not modify non-year columns
+
+Completion criteria:
+- `anio` dtype is Int64
+- Non-numeric or empty values become pd.NA
+- No rows are dropped
+- Transformation is explicit, minimal, and reversible
+"""
+
+from pathlib import Path
+import pandas as pd
+
+from .read_csv import read_registry
+from .normalize_csv import normalize_registry
+from .handle_nulls import handle_missing_values
+from .fix_cnae_cols import fix_cnae_columns
+from .fix_portalt_col import fix_portalt_column
+
+def enforce_year_to_integer(df: pd.DataFrame) -> pd.DataFrame:
+
+    df["anio"] = pd.to_numeric(df["anio"], errors="coerce").astype("Int64")
+
+    return df
+
+BASE_DIR = Path(__file__).resolve().parent
+FILE_PATH = BASE_DIR / "data" / "navarra_trimmed.csv"
+
+if __name__ == "__main__":
+
+    df = read_registry(FILE_PATH)
+    df = normalize_registry(df)
+    df = handle_missing_values(df)
+
+    df = fix_cnae_columns(df)
+    df = fix_portalt_column(df)
+
+    df = enforce_year_to_integer(df)
+
+    print("passed: anio enforced as nullable Int64.")
+

--- a/pillar3/tabular_data_cleaning/handle_free_text_fields.py
+++ b/pillar3/tabular_data_cleaning/handle_free_text_fields.py
@@ -1,0 +1,80 @@
+"""
+Drill 07 — Minimal cleaning of free-text fields
+
+Goal:
+
+- Enforce string dtype for all free-text columns
+- Assert those columns are strings
+- Assert no leading/trailing whitespaces in htese columns.
+
+Notes: 
+- All columns were originally read as string dtype, for safety
+- str.strip() was already applied in drill 2
+
+"""
+
+from pathlib import Path
+import pandas as pd
+
+from .read_csv import read_registry
+from .normalize_csv import normalize_registry
+from .handle_nulls import handle_missing_values
+from .fix_cnae_cols import fix_cnae_columns
+from .fix_portalt_col import fix_portalt_column
+from .cast_year_to_int import enforce_year_to_integer
+from .preserve_codes_as_strings import preserve_identifiers
+
+def ensure_string_columns(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
+    """
+    Ensure selected columns use pandas string dtype
+    """
+    for col in cols:
+        if col in df.columns and not pd.api.types.is_string_dtype(df[col]):
+            df[col] = df[col].astype("string")
+    return df
+
+def assert_columns_are_string(df: pd.DataFrame, cols: list[str]) -> None:
+    non_string = [
+        col for col in cols
+        if col in df.columns and not pd.api.types.is_string_dtype(df[col])
+    ]
+    assert not non_string, f"Non-string columns detected: {non_string}"
+
+def assert_no_edge_whitespace(df: pd.DataFrame, cols: list[str]) -> None:
+    subset = df[cols].dropna()
+    has_edge_ws = subset.apply(
+        lambda s: s.str.match(r"^\s|\s$", na=False)
+    ).any().any()
+
+    assert not has_edge_ws, "Leading/trailing whitespace detected"
+
+BASE_DIR = Path(__file__).resolve().parent
+FILE_PATH = BASE_DIR / "data" / "navarra_trimmed.csv"
+
+if __name__ == "__main__":
+
+    text_cols = [
+        "nombre",
+        "callet",
+        "nombre_cmun",
+        "cnae09_descrip_ppal",
+        "cnae09_descrip_local",
+        "denominacion_entidad",
+    ]
+        
+    df = read_registry(FILE_PATH)
+    df = normalize_registry(df)
+    df = handle_missing_values(df)
+    df = fix_cnae_columns(df)
+    df = fix_portalt_column(df)
+    df = enforce_year_to_integer(df)
+    df = preserve_identifiers(df, verbose=False)
+
+    df = ensure_string_columns(df, text_cols)
+
+    assert_columns_are_string(df, text_cols)
+    assert_no_edge_whitespace(df, text_cols)
+
+    # Quick sanity checks
+    print("\nDtypes:\n", df.dtypes)
+    print("\nSample rows:\n", df.head(5))

--- a/pillar3/tabular_data_cleaning/preserve_codes_as_strings.py
+++ b/pillar3/tabular_data_cleaning/preserve_codes_as_strings.py
@@ -1,0 +1,113 @@
+"""
+Drill 06 — Preserve identifiers as strings
+
+Goal:
+Protect code-like fields from numeric coercion and formatting loss.
+
+Rules:
+- Ensure identifier columns remain pandas string dtype (not numeric):
+  - dnici
+  - codpost
+  - cod_cmun
+  - id (or _id, depending on your header)
+- Never cast identifiers to numeric types
+- Do not remove leading zeros
+- Do not add or change zero-padding unless explicitly required by a rule
+- This step must NOT coerce invalid identifier values into pd.NA; it should only flag/report invalid and missing values.
+
+Completion criteria:
+- Identifier columns have dtype "string"
+- Leading zeros are preserved (spot-check dnici, cod_cmun)
+"""
+
+from pathlib import Path
+import pandas as pd
+
+from .read_csv import read_registry
+from .normalize_csv import normalize_registry
+from .handle_nulls import handle_missing_values
+from .fix_cnae_cols import fix_cnae_columns
+from .fix_portalt_col import fix_portalt_column
+from .cast_year_to_int import enforce_year_to_integer
+
+def preserve_identifiers(df: pd.DataFrame, *, verbose: bool = False) -> pd.DataFrame:
+
+    """
+    Keep identifier columns as strings so they are not broken by numeric casting.
+
+    This step:
+    - Converts identifier columns (like dnici and codpost) to pandas "string" dtype.
+    - Preserves leading zeros.
+    - Checks whether codpost and dnici look valid (without changing the data).
+    - Counts missing and invalid values for logging.
+
+    This step does NOT:
+    - Modify or fix identifier values.
+    - Replace invalid values with pd.NA.
+
+    If verbose=True, prints the counts of missing and invalid values.
+    """
+    # Enforce string dtype for identifier-like columns (preserve leading zeros)
+    base_id_cols = ["_id", "id", "dnici", "codpost", "cod_cmun"]
+    string_columns = [c for c in base_id_cols if c in df.columns]
+
+    for col in string_columns:
+        df[col] = df[col].astype("string")
+
+    # validate codpost format (5 digits for Spanish postal codes) not destructive
+    codpost_ok = None
+    if "codpost" in df.columns:
+        codpost_ok = df["codpost"].str.fullmatch(r"\d{5}", na=False)
+        codpost_ok = codpost_ok & (df["codpost"] != "00000")  # Reject 00000
+
+    # Validate dnici format (DNI, NIE, CIF) not destructive
+    dnici_ok = None
+    if "dnici" in df.columns:
+        s = df["dnici"].str.upper()
+
+        dni_ok = s.str.fullmatch(r"\d{8}[A-Z]", na=False)
+        nie_ok = s.str.fullmatch(r"[XYZ]\d{7}[A-Z]", na=False)
+        cif_ok = s.str.fullmatch(r"[ABCDEFGHJNPQRSUVW]\d{7}[0-9A-Z]", na=False)
+
+        dnici_ok = dni_ok | nie_ok | cif_ok
+
+    # Expose issues (convert counts to Python int for safe logging/serialization)
+    missing_codpost = int(df["codpost"].isna().sum()) if "codpost" in df.columns else 0
+    missing_dnici = int(df["dnici"].isna().sum()) if "dnici" in df.columns else 0
+
+    invalid_codpost = int((~codpost_ok & df["codpost"].notna()).sum())
+    invalid_dnici = int((~dnici_ok & df["dnici"].notna()).sum())
+
+
+    issues = {
+        "invalid_codpost_count": invalid_codpost,
+        "missing_codpost_count": missing_codpost,
+        "invalid_dnici_count": invalid_dnici,
+        "missing_dnici_count": missing_dnici,
+    }
+
+    if verbose:
+        for issue, count in issues.items():
+            print(f"{issue}: {count}")
+        
+    return df
+
+BASE_DIR = Path(__file__).resolve().parent
+FILE_PATH = BASE_DIR / "data" / "navarra_trimmed.csv"
+
+if __name__ == "__main__":
+
+    df = read_registry(FILE_PATH)
+    df = normalize_registry(df)
+    df = handle_missing_values(df)
+
+    df = fix_cnae_columns(df)
+    df = fix_portalt_column(df)
+
+    df = enforce_year_to_integer(df)
+
+    df = preserve_identifiers(df, verbose=True)
+
+    # Quick sanity checks
+    print("\nDtypes:\n", df.dtypes)
+    print("\nSample rows:\n", df.head(5))

--- a/pillar3/tabular_data_cleaning/remove_duplicate_rows.py
+++ b/pillar3/tabular_data_cleaning/remove_duplicate_rows.py
@@ -1,0 +1,82 @@
+"""
+Drill 08 — Remove exact duplicate rows
+
+Goal:
+Remove fully duplicated records while preserving data meaning.
+
+Rules:
+- Use pandas `df.drop_duplicates()` with default behavior
+- Do NOT specify subsets or fuzzy logic
+- Do NOT attempt to reconcile near-duplicates
+- Preserve the first occurrence of each exact row
+
+Validation:
+- Log row count before deduplication
+- Log row count after deduplication
+- Assert that the number of rows does not increase
+
+Rationale:
+Exact duplicates indicate ingestion or source duplication.
+Removing them is safe and non-destructive, unlike heuristic deduplication.
+
+Completion:
+- Deduplication is deterministic
+- No column-level logic is applied
+- No semantic assumptions are introduced
+"""
+
+from pathlib import Path
+import pandas as pd
+
+from .read_csv import read_registry
+from .normalize_csv import normalize_registry
+from .handle_nulls import handle_missing_values
+from .fix_cnae_cols import fix_cnae_columns
+from .fix_portalt_col import fix_portalt_column
+from .cast_year_to_int import enforce_year_to_integer
+from .preserve_codes_as_strings import preserve_identifiers
+from .handle_free_text_fields import ensure_string_columns
+
+def remove_duplicate_rows(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Remove exact duplicate rows using default pandas behavior.
+    """
+    before = len(df)
+    df = df.drop_duplicates()
+    after = len(df)
+
+    print(f"Row count before deduplication: {before}")
+    print(f"Row count after deduplication:  {after}")
+
+    return df
+
+def assert_duplicate_rows(df: pd.DataFrame) -> None:
+    dup_count = int(df.duplicated().sum())
+    return dup_count == 0, f"Duplicate rows detected: {dup_count}"
+
+
+BASE_DIR = Path(__file__).resolve().parent
+FILE_PATH = BASE_DIR / "data" / "navarra_trimmed.csv"
+
+if __name__ == "__main__":
+
+    text_cols = [
+        "nombre",
+        "callet",
+        "nombre_cmun",
+        "cnae09_descrip_ppal",
+        "cnae09_descrip_local",
+        "denominacion_entidad",
+    ]
+        
+    df = read_registry(FILE_PATH)
+    df = normalize_registry(df)
+    df = handle_missing_values(df)
+    df = fix_cnae_columns(df)
+    df = fix_portalt_column(df)
+    df = enforce_year_to_integer(df)
+    df = preserve_identifiers(df, verbose=False)
+    df = ensure_string_columns(df, text_cols)
+    df = remove_duplicate_rows(df)
+
+    assert_duplicate_rows(df)


### PR DESCRIPTION
Complete the remaining drills:

### Drill 05 — [Enforce year as nullable integer](cast_year_to_int.py)
**Goal:** Apply correct numeric typing without data loss.  
- Convert year columns using `pd.to_numeric(errors="coerce")`
- Cast to pandas nullable integer type `Int64`

---

### Drill 06 — [Preserve identifiers as strings](preserve_codes_as_strings.py)
**Goal:** Protect codes and identifiers.  
- Ensure columns like `dnici`, `codpost`, `cod_cmun` remain `string`
- Never cast identifiers to numeric
- Apply zero-padding only if explicitly required
- Validate identifiers (e.g. `codpost` must be exactly five digits)

---

### Drill 07 — [Minimal cleaning of free-text fields](handle_free_text_fields.py)
**Goal:** Avoid corrupting descriptive data.  
- Apply `.str.strip()` only
- No casing changes, no replacements, no normalization

---

### Drill 08 — [Remove exact duplicate rows](remove_duplicate_rows.py)
**Goal:** Deduplicate safely.  
- Use `df.drop_duplicates()`
- No fuzzy matching, no subset logic
- Log before/after row counts